### PR TITLE
Added CannedAccessControlList as a configuration option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ src_managed/
 project/boot/
 project/plugins/project/
 
-
+# Idea
+.idea/

--- a/src/main/java/ohnosequences/ivy/S3Repository.java
+++ b/src/main/java/ohnosequences/ivy/S3Repository.java
@@ -40,19 +40,13 @@ import org.apache.ivy.util.Message;
 
 /**
  * A repository the allows you to upload and download from an S3 repository.
- * 
+ *
  * @author Ben Hale
  * @author Evdokim Kovach
  */
 public class S3Repository extends AbstractRepository {
 
-	private String accessKey;
-
-	private String secretKey;
-
-    private AmazonS3Client s3Client;
-
-    private AWSCredentialsProvider credentialsProvider;
+	private AmazonS3Client s3Client;
 
 	private Map<String, S3Resource> resourceCache = new HashMap<String, S3Resource>();
 
@@ -60,23 +54,36 @@ public class S3Repository extends AbstractRepository {
 
 	private boolean overwrite;
 
+	private CannedAccessControlList acl;
+
 	public S3Repository(String accessKey, String secretKey, boolean overwrite, Region region) {
-		credentialsProvider = new InstanceProfileCredentialsProvider();
-		try {
-			credentialsProvider.getCredentials();	
-		} catch (AmazonClientException e1) {
-			credentialsProvider = new StaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey));
-		}
-		s3Client = new AmazonS3Client(credentialsProvider);
-		this.overwrite = overwrite;
-		this.region = region;
+		this(accessKey, secretKey, overwrite, region, CannedAccessControlList.Private);
 	}
 
-    public S3Repository(AWSCredentialsProvider provider, boolean overwrite, Region region) {
-        s3Client = new AmazonS3Client(provider);
-        this.overwrite = overwrite;
-        this.region = region;
-    }
+	public S3Repository(String accessKey, String secretKey, boolean overwrite, Region region, CannedAccessControlList acl) {
+		AWSCredentialsProvider provider = new InstanceProfileCredentialsProvider();
+		try {
+			provider.getCredentials();
+		} catch (AmazonClientException e1) {
+			provider = new StaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey));
+		}
+
+		s3Client = new AmazonS3Client(provider);
+		this.overwrite = overwrite;
+		this.region = region;
+		this.acl = acl;
+	}
+
+	public S3Repository(AWSCredentialsProvider provider, boolean overwrite, Region region) {
+		this(provider, overwrite, region, CannedAccessControlList.Private);
+	}
+
+	public S3Repository(AWSCredentialsProvider provider, boolean overwrite, Region region, CannedAccessControlList acl) {
+		s3Client = new AmazonS3Client(provider);
+		this.overwrite = overwrite;
+		this.region = region;
+		this.acl = acl;
+	}
 
 	public void get(String source, File destination) {
 		//System.out.println("get source=" + source + " dst=" + destination.getPath());
@@ -111,7 +118,7 @@ public class S3Repository extends AbstractRepository {
 		return resourceCache.get(source);
 	}
 
-    @Override
+	@Override
 	public List<String> list(String parent) {
 		try {
 			String marker = null;
@@ -119,10 +126,10 @@ public class S3Repository extends AbstractRepository {
 
 			do {
 				ListObjectsRequest request = new ListObjectsRequest()
-				    .withBucketName(S3Utils.getBucket(parent))
-				    .withPrefix(S3Utils.getKey(parent))
-				    .withDelimiter("/") // RFC 2396
-				    .withMarker(marker);
+						.withBucketName(S3Utils.getBucket(parent))
+						.withPrefix(S3Utils.getKey(parent))
+						.withDelimiter("/") // RFC 2396
+						.withMarker(marker);
 
 				ObjectListing listing = getS3Client().listObjects(request);
 
@@ -153,18 +160,18 @@ public class S3Repository extends AbstractRepository {
 			try {
 				attempt++;
 
-				getS3Client().createBucket(name, region);	
+				getS3Client().createBucket(name, region);
 				if(getS3Client().doesBucketExist(name)) {
-					return true;	
+					return true;
 				}
-				
+
 			} catch(AmazonS3Exception s3e) {
-				try {	
-					Message.warn(s3e.toString());				
+				try {
+					Message.warn(s3e.toString());
 					Thread.sleep(timeout);
 				} catch (InterruptedException e) {
 				}
-			}			
+			}
 		}
 		return false;
 	}
@@ -174,25 +181,25 @@ public class S3Repository extends AbstractRepository {
 		//System.out.print("parent> ");
 		String bucket = S3Utils.getBucket(destination);
 		String key = S3Utils.getKey(destination);
-       // System.out.println("publishing: bucket=" + bucket + " key=" + key);
-        PutObjectRequest request = new PutObjectRequest(bucket ,key, source);
-        request = request.withCannedAcl(CannedAccessControlList.Private);
+		// System.out.println("publishing: bucket=" + bucket + " key=" + key);
+		PutObjectRequest request = new PutObjectRequest(bucket ,key, source);
+		request = request.withCannedAcl(acl);
 
-        if (!getS3Client().doesBucketExist(bucket)) {
-        	if(!createBucket(bucket, region)) {
-        		throw new Error("couldn't create bucket");	
-        	}
-        }
+		if (!getS3Client().doesBucketExist(bucket)) {
+			if(!createBucket(bucket, region)) {
+				throw new Error("couldn't create bucket");
+			}
+		}
 
-        if (!this.overwrite && !getS3Client().listObjects(bucket, key).getObjectSummaries().isEmpty()) {
-            throw new Error(destination + " exists but overwriting is disabled");
-        }
-        getS3Client().putObject(request);
+		if (!this.overwrite && !getS3Client().listObjects(bucket, key).getObjectSummaries().isEmpty()) {
+			throw new Error(destination + " exists but overwriting is disabled");
+		}
+		getS3Client().putObject(request);
 
 	}
 
 	public AmazonS3Client getS3Client() {
-        return s3Client;		
+		return s3Client;
 	}
 
 }

--- a/src/main/java/ohnosequences/ivy/S3Resolver.java
+++ b/src/main/java/ohnosequences/ivy/S3Resolver.java
@@ -16,26 +16,37 @@
 package ohnosequences.ivy;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import org.apache.ivy.plugins.resolver.RepositoryResolver;
 import com.amazonaws.services.s3.model.Region;
 
 /**
  * A dependency resolver that looks to an S3 repository to resolve dependencies.
- * 
+ *
  * @author Ben Hale
  * @author Evdokim Kovach
  */
 public class S3Resolver extends RepositoryResolver {
-	
+
 	public S3Resolver(String name, String accessKey, String secretKey, boolean overwrite, Region region) {
 		setName(name);
 		setRepository(new S3Repository(accessKey, secretKey, overwrite, region));
 	}
 
-    public S3Resolver(String name, AWSCredentialsProvider credentialsProvider, boolean overwrite, Region region) {
-        setName(name);
-        setRepository(new S3Repository(credentialsProvider, overwrite, region));
-    }
+	public S3Resolver(String name, String accessKey, String secretKey, boolean overwrite, Region region, CannedAccessControlList acl) {
+		setName(name);
+		setRepository(new S3Repository(accessKey, secretKey, overwrite, region, acl));
+	}
+
+	public S3Resolver(String name, AWSCredentialsProvider credentialsProvider, boolean overwrite, Region region) {
+		setName(name);
+		setRepository(new S3Repository(credentialsProvider, overwrite, region));
+	}
+
+	public S3Resolver(String name, AWSCredentialsProvider credentialsProvider, boolean overwrite, Region region, CannedAccessControlList acl) {
+		setName(name);
+		setRepository(new S3Repository(credentialsProvider, overwrite, region, acl));
+	}
 
 	public String getTypeName() {
 		return "s3";

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.0-SNAPSHOT"
+version in ThisBuild := "0.7.1-SNAPSHOT"


### PR DESCRIPTION
This adds another configuration option `s3acl`, which enables you to use S3 as a public read-only repository by setting `s3acl :=  CannedAccessControlList.PublicRead`.

If not set, it defaults to `Private`, as it was set before.