### PR TITLE
Use S3 URL for S3Resource.toString() for better readability in SBT logs.

### DIFF
--- a/src/main/java/ohnosequences/ivy/S3Resource.java
+++ b/src/main/java/ohnosequences/ivy/S3Resource.java
@@ -110,4 +110,8 @@ public class S3Resource implements Resource {
 		}
 	}
 
+	@Override
+	public String toString() {
+		return name;
+	}
 }


### PR DESCRIPTION
Hi!

I just noticed that when downloading an artifact, this is what's printed in SBT logs:

```
[info] downloading ohnosequences.ivy.S3Resource@5898f1b2 ...
```

While the other Ivy resources print URLs like so:

```
[info] downloading https://repo1.maven.org/maven2/org/apache/commons/commons-dbcp2/2.1.1/commons-dbcp2-2.1.1.jar ...
```

So, I thought it'd be a bit more user-friendly to follow that convention.

If you'll need any adjustments made to the code, just let me know.
